### PR TITLE
Quarto proposal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: publish
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: quarto-dev/quarto-actions/setup@v2
+      - uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.quarto/
+/_site/
+
+**/*.quarto_ipynb

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,24 @@
+project:
+  type: website
+website:
+  title: "SciLifeLab IDS Architecture Board"
+  navbar:
+    left:
+      - text: "Home"
+        href: index.qmd
+      - procedure.qmd
+      - decisions.qmd
+      - about.qmd
+  sidebar:
+    - id: decisions
+      style: docked
+      contents: decisions
+format:
+  html:
+    theme:
+      - cosmo
+      - brand
+    css: styles.css
+    toc: true
+execute:
+  freeze: auto

--- a/about.qmd
+++ b/about.qmd
@@ -1,0 +1,12 @@
+---
+title: "About"
+---
+
+Current members of the SciLifeLab IDS Architecture Board:
+
+- Johan Viklund (NBIS)
+- Johannes Alneberg (NGI)
+- Jonas Hagberg (DC/NBIS)
+- Jonas Söderberg (NBIS-SCoRe)
+- Jonas Windhager (NBIS-BIIF)
+- Konstantin Dossis (DC)

--- a/decisions.qmd
+++ b/decisions.qmd
@@ -1,0 +1,6 @@
+---
+title: "Decisions"
+sidebar: decisions
+---
+
+This section contains all Architecture Decision Records (ADRs) of the SciLifeLab IDS Architecture Board.

--- a/decisions/ADR001-example-decision/index.qmd
+++ b/decisions/ADR001-example-decision/index.qmd
@@ -1,0 +1,5 @@
+---
+title: "ADR001: Example decision"
+---
+
+This is an example decision.

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,5 @@
+---
+title: "SciLifeLab IDS Architecture Board"
+---
+
+Welcome to the homepage of the SciLifeLab Integrated Data Services (IDS) Architecture Board.

--- a/procedure.qmd
+++ b/procedure.qmd
@@ -1,0 +1,5 @@
+---
+title: "Procedure"
+---
+
+This page outlines the decision making procedure of the SciLifeLab IDS Architecture Board.

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1 @@
+/* css styles */


### PR DESCRIPTION
I've had a quick shot at a simple quarto-based page for tracking ADRs, as one potential way how we could structure things.

To be discussed at the meeting, therefore marking this as a draft PR.

To test locally, run:

    quarto preview

Note, before merging this PR: 

> Before configuring the publishing action, it’s important that you run quarto publish gh-pages locally, once. This will create the _publish.yml configuration required by the subsequent invocations of the GitHub Action.

https://quarto.org/docs/publishing/github-pages.html#publish-action